### PR TITLE
Allow optionally giving VoseAlias an RNG to use

### DIFF
--- a/vose_sampler/vose_sampler.py
+++ b/vose_sampler/vose_sampler.py
@@ -20,9 +20,10 @@ class VoseAlias(object):
     http://www.keithschwarz.com/darts-dice-coins/).
     """
 
-    def __init__(self, dist):
-        """ (VoseAlias, dict) -> NoneType """
+    def __init__(self, dist, rng=None):
+        """ (VoseAlias, dict[, RNG]) -> NoneType """
         self.dist = dist
+        self.rng = rng or random.Random()
         self.alias_initialisation()
         self.table_prob_list = list(self.table_prob)
 
@@ -68,10 +69,10 @@ class VoseAlias(object):
     def alias_generation(self):
         """ Return a random outcome from the distribution. """
         # Determine which column of table_prob to inspect
-        col = random.choice(self.table_prob_list)
+        col = self.rng.choice(self.table_prob_list)
 
         # Determine which outcome to pick in that column
-        if self.table_prob[col] >= random.uniform(0,1):
+        if self.table_prob[col] >= self.rng.uniform(0,1):
             return col
         else:
             return self.table_alias[col]


### PR DESCRIPTION
Allow optionally giving VoseAlias a random number generator to use for random sampling, which can be used to e.g. achieve repeatable results by passing in an RNG created with a consistent seed, rather than relying on the `random` standard library's state. If no RNG is given, then one is created.