### PR TITLE
Replace random.uniform(0, 1) with faster equivalent random.random()

### DIFF
--- a/vose_sampler/vose_sampler.py
+++ b/vose_sampler/vose_sampler.py
@@ -71,7 +71,7 @@ class VoseAlias(object):
         col = random.choice(self.table_prob_list)
 
         # Determine which outcome to pick in that column
-        if self.table_prob[col] >= random.uniform(0,1):
+        if self.table_prob[col] >= random.random():
             return col
         else:
             return self.table_alias[col]


### PR DESCRIPTION
Replace the `random.uniform(0, 1)` call with the faster equivalent `random.random()`.

`random()` is more than 3x faster than `uniform(0, 1)` in my testing:

```python
>>> import random
>>> from timeit import timeit
>>> timeit('random.uniform(0, 1)', globals=dict(random=random))
0.144...
>>> timeit('random.random()', globals=dict(random=random))
0.044...
```