### PR TITLE
Allow sampling zero items

### DIFF
--- a/vose_sampler/vose_sampler.py
+++ b/vose_sampler/vose_sampler.py
@@ -81,8 +81,8 @@ class VoseAlias(object):
         """ Return a sample of size n from the distribution."""
         # Ensure a non-negative integer as been specified
         n = int(size)
-        if n <= 0:
-            raise ValueError("Please enter a non-negative integer for the number of samples desired: %d" % n)
+        if n < 0:
+            raise ValueError(f"Please enter a non-negative integer for the number of samples desired. size={n}")
 
         return [self.alias_generation() for i in range(n)]
 


### PR DESCRIPTION
Sorry to make another pull request! Last one I promise 😅 

Allow `sample_n(size)` to take zero samples, returning an empty list `[]`.

Because `sample_n()` does not currently allow `size=0`, calling code ends up having to do this kind of funky thing:

`samples = va.sample_n(size) if size > 0 else []`

Which is not very elegant. It would be nicer if we could just call `sample_n()` and get an empty list back.